### PR TITLE
Update images to our own non-internal image

### DIFF
--- a/charts/fraud-detection/templates/job-create-fraud-detection-pipeline.yaml
+++ b/charts/fraud-detection/templates/job-create-fraud-detection-pipeline.yaml
@@ -50,7 +50,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: bootstrap
-          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          image: quay.io/validatedpatterns/utility-container:latest
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/charts/minio/templates/job-create-ds-connections.yaml
+++ b/charts/minio/templates/job-create-ds-connections.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: create-ds-connections
-          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          image: quay.io/validatedpatterns/utility-container:latest
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash

--- a/charts/minio/templates/job-create-minio-buckets.yaml
+++ b/charts/minio/templates/job-create-minio-buckets.yaml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       initContainers:
         - name: wait-for-minio
-          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          image: quay.io/validatedpatterns/utility-container:latest
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash
@@ -38,7 +38,7 @@ spec:
               sleep 10
       containers:
         - name: create-buckets
-          image: image-registry.openshift-image-registry.svc:5000/redhat-ods-applications/s2i-generic-data-science-notebook:2024.1
+          image: quay.io/validatedpatterns/utility-container:latest
           imagePullPolicy: IfNotPresent
           envFrom:
             - secretRef:

--- a/charts/minio/templates/job-create-minio-root-user.yaml
+++ b/charts/minio/templates/job-create-minio-root-user.yaml
@@ -14,7 +14,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: create-minio-root-user
-          image: image-registry.openshift-image-registry.svc:5000/openshift/tools:latest
+          image: quay.io/validatedpatterns/utility-container:latest
           imagePullPolicy: IfNotPresent
           command:
             - /bin/bash


### PR DESCRIPTION
This way an internal in-cluster registry is not even needed for this pattern
and our image has all the needed deps and is needed anyways, so this
makes sense.
