### PR TITLE
fix: change minio/s3 to serve http too

### DIFF
--- a/charts/fraud-detection/templates/dspa.yaml
+++ b/charts/fraud-detection/templates/dspa.yaml
@@ -22,4 +22,4 @@ spec:
         accessKey: AWS_ACCESS_KEY_ID
         secretKey: AWS_SECRET_ACCESS_KEY
         secretName: aws-connection-pipeline-artifacts
-      scheme: https
+      scheme: http

--- a/charts/minio/templates/job-create-ds-connections.yaml
+++ b/charts/minio/templates/job-create-ds-connections.yaml
@@ -30,7 +30,7 @@ spec:
 
               MINIO_ROOT_USER=$(oc get secret minio-root-user -o jsonpath='{.data.MINIO_ROOT_USER}' | base64 -d)
               MINIO_ROOT_PASSWORD=$(oc get secret minio-root-user -o jsonpath='{.data.MINIO_ROOT_PASSWORD}' | base64 -d)
-              MINIO_HOST=https://$(oc get route minio-s3 -o jsonpath='{.spec.host}')
+              MINIO_HOST=http://$(oc get route minio-s3 -o jsonpath='{.spec.host}')
 
               # Common S3 JSON with verify_ssl for my-storage
               STORAGE_JSON=$(cat <<EOF

--- a/charts/minio/templates/route-console.yaml
+++ b/charts/minio/templates/route-console.yaml
@@ -9,7 +9,7 @@ spec:
   port:
     targetPort: console
   tls:
-    insecureEdgeTerminationPolicy: Redirect
+    insecureEdgeTerminationPolicy: Allow
     termination: edge
   to:
     kind: Service

--- a/charts/minio/templates/route-s3.yaml
+++ b/charts/minio/templates/route-s3.yaml
@@ -9,7 +9,7 @@ spec:
   port:
     targetPort: api
   tls:
-    insecureEdgeTerminationPolicy: Redirect
+    insecureEdgeTerminationPolicy: Allow
     termination: edge
   to:
     kind: Service


### PR DESCRIPTION
This is a workaround.
OpenshiftAI/pipelines does not mount the ca anymore to the place
where the used image would expect.
